### PR TITLE
Fix template variable deprecation warnings for Puppet > 3.2

### DIFF
--- a/templates/Debian/default.erb
+++ b/templates/Debian/default.erb
@@ -33,6 +33,6 @@ PARAMS="--backlog=<%= @backlog %> \
 <% end -%>
 <% if @queue_type -%>
 --queue-type=<%= @queue_type %> \
-<%= queue_params %> \
+<%= @queue_params %> \
 <% end -%>
 "

--- a/templates/RedHat/default.erb
+++ b/templates/RedHat/default.erb
@@ -17,22 +17,22 @@
 #                   --mysql-table=gearman_queue"
 #
 
-OPTIONS="--backlog=<%= backlog %> \
---job-retries=<%= job_retries %> \
---port=<%= port %> \
---listen=<%= listen %> \
---threads=<%= threads %> \
---file-descriptors=<%= maxfiles %> \
---worker-wakeup=<%= worker_wakeup %> \
+OPTIONS="--backlog=<%= @backlog %> \
+--job-retries=<%= @job_retries %> \
+--port=<%= @port %> \
+--listen=<%= @listen %> \
+--threads=<%= @threads %> \
+--file-descriptors=<%= @maxfiles %> \
+--worker-wakeup=<%= @worker_wakeup %> \
 <% if @verbose -%>
---verbose=<%= verbose %> \
+--verbose=<%= @verbose %> \
 <% end -%>
 <% if @queue_type -%>
---queue-type=<%= queue_type %> \
-<%= queue_params %> \
+--queue-type=<%= @queue_type %> \
+<%= @queue_params %> \
 <% end -%>
 <% if @log_file -%>
---log-file=<%= log_file %> \
+--log-file=<%= @log_file %> \
 <% else -%>
 --log-file=/var/log/gearmand/gearmand.log \
 <% end -%>


### PR DESCRIPTION
This is a fix for template variable deprecation warnings in Puppet versions greater than 3.2. Should be pretty straightforward. Tests passing locally.
